### PR TITLE
[Fix] Railway deployment - root Dockerfiles and PORT/CORS production support

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["src/QSS.API/QSS.API.csproj", "src/QSS.API/"]
+COPY ["src/QSS.Application/QSS.Application.csproj", "src/QSS.Application/"]
+COPY ["src/QSS.Domain/QSS.Domain.csproj", "src/QSS.Domain/"]
+COPY ["src/QSS.Infrastructure/QSS.Infrastructure.csproj", "src/QSS.Infrastructure/"]
+RUN dotnet restore "src/QSS.API/QSS.API.csproj"
+COPY . .
+WORKDIR "/src/src/QSS.API"
+RUN dotnet publish "QSS.API.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+RUN mkdir -p /app/data /app/wwwroot/uploads
+COPY --from=build /app/publish .
+ENV ASPNETCORE_ENVIRONMENT=Production
+ENTRYPOINT ["dotnet", "QSS.API.dll"]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["src/QSS.Web/QSS.Web.csproj", "src/QSS.Web/"]
+COPY ["src/QSS.Application/QSS.Application.csproj", "src/QSS.Application/"]
+COPY ["src/QSS.Domain/QSS.Domain.csproj", "src/QSS.Domain/"]
+COPY ["src/QSS.Infrastructure/QSS.Infrastructure.csproj", "src/QSS.Infrastructure/"]
+RUN dotnet restore "src/QSS.Web/QSS.Web.csproj"
+COPY . .
+WORKDIR "/src/src/QSS.Web"
+RUN dotnet publish "QSS.Web.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV ASPNETCORE_ENVIRONMENT=Production
+ENTRYPOINT ["dotnet", "QSS.Web.dll"]

--- a/src/QSS.API/Program.cs
+++ b/src/QSS.API/Program.cs
@@ -76,10 +76,13 @@ builder.Services.AddScoped<DashboardService>();
 builder.Services.AddScoped<QrCodeService>();
 
 // CORS for the Web frontend
+// In production, set Cors__AllowedOrigins__0=https://<web-service>.up.railway.app via Railway env vars
+var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
+    ?? new[] { "http://localhost:5001", "https://localhost:5001" };
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowWebFrontend", policy =>
-        policy.WithOrigins("http://localhost:5001", "https://localhost:5001")
+        policy.WithOrigins(allowedOrigins)
               .AllowAnyHeader()
               .AllowAnyMethod()
               .AllowCredentials());
@@ -146,4 +149,6 @@ app.MapHub<NotificationHub>("/hubs/notifications");
 // Redirect root to swagger
 app.MapGet("/", () => Results.Redirect("/swagger"));
 
-app.Run();
+// Use Railway's dynamic PORT env var if present, otherwise default to 8080
+var port = Environment.GetEnvironmentVariable("PORT") ?? "8080";
+app.Run($"http://+:{port}");

--- a/src/QSS.API/appsettings.json
+++ b/src/QSS.API/appsettings.json
@@ -7,6 +7,9 @@
     "Issuer": "QSS",
     "Audience": "QSS"
   },
+  "Cors": {
+    "AllowedOrigins": [ "http://localhost:5001", "https://localhost:5001" ]
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/QSS.Web/Program.cs
+++ b/src/QSS.Web/Program.cs
@@ -48,4 +48,6 @@ app.MapGet("/", context =>
     return Task.CompletedTask;
 });
 
-app.Run();
+// Use Railway's dynamic PORT env var if present, otherwise default to 8080
+var port = Environment.GetEnvironmentVariable("PORT") ?? "8080";
+app.Run($"http://+:{port}");


### PR DESCRIPTION
Fixes #3

## What was changed

### New files
- `Dockerfile.api` at repo root — full repo build context, fixes missing csproj error
- `Dockerfile.web` at repo root — full repo build context

### Modified files
- `src/QSS.API/Program.cs` — PORT env var support, configurable CORS origins
- `src/QSS.API/appsettings.json` — added Cors:AllowedOrigins with localhost defaults
- `src/QSS.Web/Program.cs` — PORT env var support

## Database changes
None

## How to test
1. On Railway: set Dockerfile Path to `Dockerfile.api` / `Dockerfile.web` with repo root as build context
2. Set required env vars per service (see issue #3 comment)
3. Deploy — both services should build and start without missing csproj errors
4. Local docker-compose remains unchanged and still works

Generated with [Claude Code](https://claude.ai/code)