### PR TITLE
fix: remove misleading port 5000 error message on login failure

### DIFF
--- a/src/QSS.Web/Pages/Login.cshtml.cs
+++ b/src/QSS.Web/Pages/Login.cshtml.cs
@@ -83,7 +83,7 @@ public class LoginModel : PageModel
         catch (Exception ex)
         {
             _logger.LogError(ex, "Login failed");
-            ErrorMessage = "Unable to connect to the server. Make sure the API is running on port 5000.";
+            ErrorMessage = "Unable to connect to the API server. Please check your connection and try again.";
             return Page();
         }
     }


### PR DESCRIPTION
Fixes #5

Removes the hardcoded "port 5000" error message in `Login.cshtml.cs` that was misleading Railway's deployment agent into thinking port 5000 was required. The message now reads generically: "Unable to connect to the API server. Please check your connection and try again."

Generated with [Claude Code](https://claude.ai/code)