### PR TITLE
fix: resolve Railway deployment failures

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -14,6 +14,7 @@ RUN dotnet publish "QSS.API.csproj" -c Release -o /app/publish /p:UseAppHost=fal
 
 FROM base AS final
 WORKDIR /app
+EXPOSE 8080
 RUN mkdir -p /app/data /app/wwwroot/uploads
 COPY --from=build /app/publish .
 ENV ASPNETCORE_ENVIRONMENT=Production

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -14,6 +14,7 @@ RUN dotnet publish "QSS.Web.csproj" -c Release -o /app/publish /p:UseAppHost=fal
 
 FROM base AS final
 WORKDIR /app
+EXPOSE 8080
 COPY --from=build /app/publish .
 ENV ASPNETCORE_ENVIRONMENT=Production
 ENTRYPOINT ["dotnet", "QSS.Web.dll"]

--- a/src/QSS.API/Program.cs
+++ b/src/QSS.API/Program.cs
@@ -149,6 +149,9 @@ app.MapControllers();
 app.MapHub<ChatHub>("/hubs/chat");
 app.MapHub<NotificationHub>("/hubs/notifications");
 
+// Health check endpoint for Railway
+app.MapGet("/health", () => Results.Ok(new { status = "healthy" }));
+
 // Redirect root to swagger
 app.MapGet("/", () => Results.Redirect("/swagger"));
 

--- a/src/QSS.API/appsettings.json
+++ b/src/QSS.API/appsettings.json
@@ -8,7 +8,7 @@
     "Audience": "QSS"
   },
   "Cors": {
-    "AllowedOrigins": [ "http://localhost:5001", "https://localhost:5001" ]
+    "AllowedOrigins": [ "http://localhost:5001", "https://localhost:5001", "https://qss-web-production.up.railway.app" ]
   },
   "Logging": {
     "LogLevel": {

--- a/src/QSS.Web/Pages/Login.cshtml.cs
+++ b/src/QSS.Web/Pages/Login.cshtml.cs
@@ -43,9 +43,16 @@ public class LoginModel : PageModel
             var client = _httpClientFactory.CreateClient("QssApi");
             var response = await client.PostAsJsonAsync("/api/auth/login", new { email, password });
 
-            if (!response.IsSuccessStatusCode)
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
             {
                 ErrorMessage = "Invalid credentials. Please try again.";
+                return Page();
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("API login failed with status {StatusCode}", response.StatusCode);
+                ErrorMessage = "Login service error. Please try again later.";
                 return Page();
             }
 


### PR DESCRIPTION
Fixes #8

## What was wrong

- `Dockerfile.api` and `Dockerfile.web` were missing `EXPOSE 8080` — Railway couldn't detect the service port, causing "Container failed to start"
- No health check endpoint for Railway to verify startup
- CORS only allowed localhost, blocking browser-side calls from the Railway web domain
- Login page showed "Invalid credentials" for all failures including API server errors

## Affected modules

- `Dockerfile.api`, `Dockerfile.web`
- `src/QSS.API/Program.cs`
- `src/QSS.API/appsettings.json`
- `src/QSS.Web/Pages/Login.cshtml.cs`

## How to test

1. Merge this PR and let Railway redeploy
2. Set Railway env vars: `ApiBaseUrl` for qss-web, volume at `/app/data` for qss-api
3. Try logging in at https://qss-web-production.up.railway.app/Login with superadmin@qss.com / Admin@1234!
4. Check https://qss-api-production.up.railway.app/health returns 200
5. Check https://qss-api-production.up.railway.app/swagger loads

Generated with [Claude Code](https://claude.ai/code)