### PR TITLE
fix: Railway deployment - startup crash handling and railway.toml

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,8 @@
+[build]
+dockerfilePath = "Dockerfile.api"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 120
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/src/QSS.API/Program.cs
+++ b/src/QSS.API/Program.cs
@@ -127,10 +127,19 @@ var app = builder.Build();
 // Seed database
 using (var scope = app.Services.CreateScope())
 {
-    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-    var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
-    var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
-    await DbSeeder.SeedAsync(db, userManager, roleManager);
+    var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+    try
+    {
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+        await DbSeeder.SeedAsync(db, userManager, roleManager);
+        logger.LogInformation("Database seeding completed successfully.");
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "Database seeding failed. The application will start with the existing database state.");
+    }
 }
 
 app.UseSwagger();


### PR DESCRIPTION
Fixes #10

## Changes

- Wrap DbSeeder in try-catch so container starts even if seeding fails, with error logged to Railway logs
- Add `railway.toml` with explicit Dockerfile path, 120s health check timeout, and restart policy

## How to Test

1. Merge this PR
2. Redeploy `qss-api` on Railway
3. If it still fails, check Railway → Service → Logs for the actual error message
4. Set required env vars listed in issue #10

Generated with [Claude Code](https://claude.ai/code)