### PR TITLE
Fix false 'Failed to update status' toast on task status change

### DIFF
--- a/src/QSS.API/Controllers/TasksController.cs
+++ b/src/QSS.API/Controllers/TasksController.cs
@@ -148,11 +148,17 @@ public class TasksController : ControllerBase
 
         // Trigger: when a task is completed, activate any tasks that depend on it
         if (dto.Status == QssTaskStatus.Completed)
-            await ActivateDependentTasks(id);
+        {
+            try { await ActivateDependentTasks(id); }
+            catch (Exception ex) { Console.Error.WriteLine($"[TasksController] ActivateDependentTasks failed for task {id}: {ex.Message}"); }
+        }
 
         // Trigger: log device history when a device-linked task is completed
         if (dto.Status == QssTaskStatus.Completed && task.DeviceId.HasValue)
-            await LogDeviceTaskCompletion(task);
+        {
+            try { await LogDeviceTaskCompletion(task); }
+            catch (Exception ex) { Console.Error.WriteLine($"[TasksController] LogDeviceTaskCompletion failed for task {id}: {ex.Message}"); }
+        }
 
         return NoContent();
     }

--- a/src/QSS.Web/Pages/Tasks.cshtml
+++ b/src/QSS.Web/Pages/Tasks.cshtml
@@ -661,18 +661,26 @@ function tasksApp() {
             const status = isNaN(statusValue) ? (statusMap[statusValue] ?? 0) : parseInt(statusValue);
             try {
                 await apiRequest('PATCH', `/tasks/${id}/status`, { status });
-                await this.load();
-                showToast('Status updated');
-            } catch(e) { showToast('Failed to update status', 'error'); }
+            } catch(e) {
+                showToast('Failed to update status', 'error');
+                return;
+            }
+            showToast('Status updated');
+            await this.load();
         },
 
         async updateStatusAndRefresh(id, status) {
             try {
                 await apiRequest('PATCH', `/tasks/${id}/status`, { status });
+            } catch(e) {
+                showToast('Failed to update status', 'error');
+                return;
+            }
+            showToast('Status updated');
+            try {
                 this.selectedTask = await apiRequest('GET', `/tasks/${id}`);
                 await this.load();
-                showToast('Status updated');
-            } catch(e) { showToast('Failed to update status', 'error'); }
+            } catch(e) { /* refresh after status update — failure is non-critical */ }
         },
 
         async deleteTask(id) {


### PR DESCRIPTION
Fixes #36

## Changes

**Backend (TasksController.cs)**: Wrapped `ActivateDependentTasks` and `LogDeviceTaskCompletion` in individual try-catch blocks so side-effect failures after a successful `SaveChangesAsync` no longer cause a 500 response.

**Frontend (Tasks.cshtml)**: Separated the PATCH error boundary from the UI refresh error boundary in `updateStatus` and `updateStatusAndRefresh`. The success/error toast is now determined solely by the PATCH result.

Generated with [Claude Code](https://claude.ai/code)